### PR TITLE
Publish on hackage flow.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: publish
+
+on:
+  push:
+    branches:
+      - main
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: cabal check
+
+      - uses: sol/haskell-autotag@v1
+        id: autotag
+        with:
+          prefix: v
+
+      - run: cabal sdist
+      - uses: haskell-actions/hackage-publish@v1.1
+        with:
+          hackageToken: ${{ secrets.HACKAGE_AUTH_TOKEN }}
+          publish: false
+        if: steps.autotag.outputs.created

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - run: cabal check
 


### PR DESCRIPTION
Tags and publishes to hackage (for now as a candidate) as soon as a new version appears in the source code.
Should simplify release processes in future...

See also https://github.com/co-log/co-log/issues/249

Test in conjunction with https://github.com/co-log/co-log-polysemy/issues/15

For this to work we need a repo or organization secret.
```${{ secrets.HACKAGE_AUTH_TOKEN }}```